### PR TITLE
Don't show edit/delete on other user ballots

### DIFF
--- a/app/views/ballots/_ballots_table.html.haml
+++ b/app/views/ballots/_ballots_table.html.haml
@@ -1,0 +1,19 @@
+%table.table.table-striped
+  %tbody
+    %tr
+      %th
+        Keg
+      %th
+        Voter
+      %th
+      %th
+    - ballots.each do |ballot|
+      %tr
+        %td
+          #{ ballot.beer.brand }
+        %td
+          #{ ballot.user.username }
+        %td
+          =link_to "Edit", edit_ballot_path(ballot)
+        %td
+          =link_to "Delete", ballot_path(ballot), method: :delete, data: { confirm: "Are you sure you want to delete your ballot?" }

--- a/app/views/ballots/_ballots_table.html.haml
+++ b/app/views/ballots/_ballots_table.html.haml
@@ -12,9 +12,11 @@
         %td= ballot.beer.brand
         %td= ballot.user.username
         %td
-          = link_to "Edit", edit_ballot_path(ballot)
+          - if can? :edit, ballot
+            = link_to "Edit", edit_ballot_path(ballot)
         %td
-          = link_to "Delete",
-            ballot_path(ballot),
-            method: :delete,
-            data: { confirm: "Are you sure you want to delete your ballot?" }
+          - if can? :delete, ballot
+            = link_to "Delete",
+              ballot_path(ballot),
+              method: :delete,
+              data: { confirm: "Are you sure you want to delete your ballot?" }

--- a/app/views/ballots/_ballots_table.html.haml
+++ b/app/views/ballots/_ballots_table.html.haml
@@ -9,11 +9,12 @@
       %th
     - ballots.each do |ballot|
       %tr
+        %td= ballot.beer.brand
+        %td= ballot.user.username
         %td
-          #{ ballot.beer.brand }
+          = link_to "Edit", edit_ballot_path(ballot)
         %td
-          #{ ballot.user.username }
-        %td
-          =link_to "Edit", edit_ballot_path(ballot)
-        %td
-          =link_to "Delete", ballot_path(ballot), method: :delete, data: { confirm: "Are you sure you want to delete your ballot?" }
+          = link_to "Delete",
+            ballot_path(ballot),
+            method: :delete,
+            data: { confirm: "Are you sure you want to delete your ballot?" }

--- a/app/views/ballots/index.html.haml
+++ b/app/views/ballots/index.html.haml
@@ -9,22 +9,4 @@
   -poll_presenter = PollPresenter.new(poll)
   = poll_presenter.number_of_votes
   = pie_chart poll_presenter.piechart_data, colors: ["brown"]
-%table.table.table-striped
-  %tbody
-    %tr
-      %th
-        Keg
-      %th
-        Voter
-      %th
-      %th
-    -poll.ballots.each do |ballot|
-      %tr
-        %td
-          #{ ballot.beer.brand }
-        %td
-          #{ ballot.user.username }
-        %td
-          =link_to "Edit", edit_ballot_path(ballot)
-        %td
-          =link_to "Delete", ballot_path(ballot), method: :delete, data: { confirm: "Are you sure you want to delete you ballot?" }
+= render 'ballots_table', ballots: poll.ballots


### PR DESCRIPTION
This change addresses issue #25 where users see an Edit/Delete
on other user's ballots even though they have no ability to do so.

It also pulls the table into a partial and cleans up the mark-up a bit.
