### PR TITLE
Fix selecting poll winner and add specs

### DIFF
--- a/app/models/poll.rb
+++ b/app/models/poll.rb
@@ -10,8 +10,8 @@ class Poll < ActiveRecord::Base
 
   def finalize
     if self.ballots.any?
-      find_winner
-      lock
+      pick_winner!
+      close!
     end
   end
 
@@ -25,7 +25,7 @@ class Poll < ActiveRecord::Base
 
   private
 
-  def find_winner
+  def pick_winner!
     winning_beer_id = ballots.
       select("beer_id, COUNT(id) AS ballot_count").
       group(:beer_id).
@@ -35,7 +35,7 @@ class Poll < ActiveRecord::Base
     update(winner_id: winning_beer_id)
   end
 
-  def lock
+  def close!
     update(closed: true)
   end
 end

--- a/app/models/poll.rb
+++ b/app/models/poll.rb
@@ -5,7 +5,7 @@ class Poll < ActiveRecord::Base
 
   def self.current
     return last unless !any? || last.closed?
-      nil
+    nil
   end
 
   def finalize
@@ -16,7 +16,12 @@ class Poll < ActiveRecord::Base
   end
 
   def find_winner
-    beer_id = ballots.select("beer_id, COUNT(id) AS ballot_count").group(:beer_id).order("ballot_count").first.beer_id
+    beer_id = ballots.
+      select("beer_id, COUNT(id) AS ballot_count").
+      group(:beer_id).
+      order("ballot_count").
+      first.
+      beer_id
     winner = Beer.where(id: beer_id)
     self.update(winner: winner)
   end

--- a/app/models/poll.rb
+++ b/app/models/poll.rb
@@ -15,6 +15,16 @@ class Poll < ActiveRecord::Base
     end
   end
 
+  def next
+    Poll.where("id > ?", id).first
+  end
+
+  def previous
+    Poll.where("id < ?", id).last
+  end
+
+  private
+
   def find_winner
     winning_beer_id = ballots.
       select("beer_id, COUNT(id) AS ballot_count").
@@ -26,14 +36,6 @@ class Poll < ActiveRecord::Base
   end
 
   def lock
-    self.update(closed: true)
-  end
-
-  def next
-    Poll.where("id > ?", id).first
-  end
-
-  def previous
-    Poll.where("id < ?", id).last
+    update(closed: true)
   end
 end

--- a/app/models/poll.rb
+++ b/app/models/poll.rb
@@ -16,14 +16,13 @@ class Poll < ActiveRecord::Base
   end
 
   def find_winner
-    beer_id = ballots.
+    winning_beer_id = ballots.
       select("beer_id, COUNT(id) AS ballot_count").
       group(:beer_id).
-      order("ballot_count").
+      order("ballot_count DESC").
       first.
       beer_id
-    winner = Beer.where(id: beer_id)
-    self.update(winner: winner)
+    update(winner_id: winning_beer_id)
   end
 
   def lock

--- a/spec/factories/polls.rb
+++ b/spec/factories/polls.rb
@@ -2,5 +2,4 @@ FactoryGirl.define do
   factory :poll do
     closed false
   end
-
 end

--- a/spec/models/poll_spec.rb
+++ b/spec/models/poll_spec.rb
@@ -4,9 +4,30 @@ RSpec.describe Poll, type: :model do
   it { is_expected.to have_many :ballots }
   it { is_expected.to have_many :users }
 
-  let!(:polls) { FactoryGirl.create_list :poll, 2 }
+  let(:poll) { FactoryGirl.create :poll }
+
+  describe '#find_winner' do
+    subject { poll.find_winner }
+
+    let(:winner) { FactoryGirl.create :beer }
+    let(:loser) { FactoryGirl.create :beer }
+
+    before do
+      FactoryGirl.create_list :ballot, 2, beer: winner, poll: poll
+      FactoryGirl.create :ballot, beer: loser, poll: poll
+    end
+
+    it 'sets the winner_id to the beer with most ballots' do
+      expect { subject }.to change { poll.winner }.
+        from(nil).to(winner)
+    end
+  end
+
   describe '#previous_poll' do
     subject { Poll.last.previous }
+
+    let!(:polls) { FactoryGirl.create_list :poll, 2 }
+
     it "should return the previous poll" do
       expect(subject).to eq(Poll.first)
     end
@@ -14,6 +35,9 @@ RSpec.describe Poll, type: :model do
 
   describe '#next_poll' do
     subject { Poll.first.next }
+
+    let!(:polls) { FactoryGirl.create_list :poll, 2 }
+
     it "should return the next poll" do
       expect(subject).to eq(Poll.last)
     end

--- a/spec/models/poll_spec.rb
+++ b/spec/models/poll_spec.rb
@@ -6,8 +6,8 @@ RSpec.describe Poll, type: :model do
 
   let(:poll) { FactoryGirl.create :poll }
 
-  describe '#find_winner' do
-    subject { poll.find_winner }
+  describe '#finalize' do
+    subject { poll.finalize }
 
     let(:winner) { FactoryGirl.create :beer }
     let(:loser) { FactoryGirl.create :beer }
@@ -20,6 +20,11 @@ RSpec.describe Poll, type: :model do
     it 'sets the winner_id to the beer with most ballots' do
       expect { subject }.to change { poll.winner }.
         from(nil).to(winner)
+    end
+
+    it 'closes the poll' do
+      expect { subject }.to change { poll.closed }.
+        from(false).to(true)
     end
   end
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -19,6 +19,8 @@ RSpec.configure do |config|
   config.include Devise::TestHelpers, type: :controller
   config.include Devise::TestHelpers, type: :view
 
+  config.include FactoryGirl::Syntax::Methods
+
   config.before :suite do
     DatabaseCleaner.clean_with :truncation
   end


### PR DESCRIPTION
This change fixes an ActiveRecord mismatch error when finding the poll
winner and assigning the winning beer id.

This change also cleans-up the external API of the Poll model by making some
of the helper methods private.
