### PR TITLE
Don't allow editing of ballots after poll closes

### DIFF
--- a/app/models/poll.rb
+++ b/app/models/poll.rb
@@ -8,6 +8,10 @@ class Poll < ActiveRecord::Base
     nil
   end
 
+  def open?
+    !closed
+  end
+
   def finalize
     if self.ballots.any?
       pick_winner!

--- a/app/views/ballots/_ballots_table.html.haml
+++ b/app/views/ballots/_ballots_table.html.haml
@@ -7,15 +7,15 @@
         Voter
       %th
       %th
-    - ballots.each do |ballot|
+    - poll.ballots.each do |ballot|
       %tr
         %td= ballot.beer.brand
         %td= ballot.user.username
         %td
-          - if can? :edit, ballot
+          - if poll.open? && can?(:edit, ballot)
             = link_to "Edit", edit_ballot_path(ballot)
         %td
-          - if can? :delete, ballot
+          - if poll.open? && can?(:delete, ballot)
             = link_to "Delete",
               ballot_path(ballot),
               method: :delete,

--- a/app/views/ballots/index.html.haml
+++ b/app/views/ballots/index.html.haml
@@ -9,4 +9,4 @@
   -poll_presenter = PollPresenter.new(poll)
   = poll_presenter.number_of_votes
   = pie_chart poll_presenter.piechart_data, colors: ["brown"]
-= render 'ballots_table', ballots: poll.ballots
+= render 'ballots_table', poll: poll

--- a/spec/models/poll_spec.rb
+++ b/spec/models/poll_spec.rb
@@ -4,7 +4,21 @@ RSpec.describe Poll, type: :model do
   it { is_expected.to have_many :ballots }
   it { is_expected.to have_many :users }
 
-  let(:poll) { FactoryGirl.create :poll }
+  let(:poll) { FactoryGirl.create :poll, closed: closed }
+  let(:closed) { false }
+
+  describe '#open?' do
+    subject { poll.open? }
+
+    context 'when poll is open' do
+      it { is_expected.to be true }
+    end
+
+    context 'when poll is closed' do
+      let(:closed) { true }
+      it { is_expected.to be false }
+    end
+  end
 
   describe '#finalize' do
     subject { poll.finalize }


### PR DESCRIPTION
This change fixes an issue (#30) which allows users to edit and delete
their ballots after a poll has closed.

This pull request depends on https://github.com/StemboltHQ/keg_picker/pull/28
