### PR TITLE
Hide admin links from non-admin users

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -2,7 +2,7 @@ class Ability
   include CanCan::Ability
 
   def initialize(user)
-    user ||=User.new
+    user ||= User.new
     if user.has_role? :admin
       can :manage, :all
     else

--- a/app/views/beers/index.html.haml
+++ b/app/views/beers/index.html.haml
@@ -11,6 +11,8 @@
     %tr
       %td= "#{beer.display_name}"
       %td
-        = link_to "Delete", beer_path(beer), method: :delete, data: { confirm: "Are you sure you want to delete this beer?" }
+        - if can? :delete, beer
+          = link_to "Delete", beer_path(beer), method: :delete, data: { confirm: "Are you sure you want to delete this beer?" }
       %td
-        = link_to "Edit", edit_beer_path(beer)
+        - if can? :edit, beer
+          = link_to "Edit", edit_beer_path(beer)

--- a/app/views/layouts/_navbar.html.haml
+++ b/app/views/layouts/_navbar.html.haml
@@ -3,4 +3,5 @@
     %li= link_to "Vote!", new_ballot_path
     %li= link_to "Polls", polls_path
     %li= link_to "Beers", beers_path
-    %li= link_to "Add a beer", new_beer_path
+    - if can? :create, Beer
+      %li= link_to "Add a beer", new_beer_path


### PR DESCRIPTION
Permissions are already checked on most links, but I think this covers all the remaining ones.

This closes #23 
