### PR TITLE
Require users to sign in before voting

### DIFF
--- a/app/controllers/ballots_controller.rb
+++ b/app/controllers/ballots_controller.rb
@@ -2,6 +2,7 @@ class BallotsController < ApplicationController
   before_filter :load_beer, only: [:create]
   before_filter :load_ballot, only: [:edit, :update, :destroy]
   before_filter :load_all_beers, only: [:new, :edit, :create]
+  before_action :authenticate_user!, only: :new
   authorize_resource
 
   def new

--- a/spec/controllers/ballots_controller_spec.rb
+++ b/spec/controllers/ballots_controller_spec.rb
@@ -49,32 +49,40 @@ RSpec.describe BallotsController, type: :controller do
   describe "GET #new" do
     subject { get :new }
 
-    context "when there is an open poll" do
-      let!(:poll) { FactoryGirl.create :poll }
+    context "when a user is logged in" do
+      context "when there is an open poll" do
+        let!(:poll) { FactoryGirl.create :poll }
 
-      it "assigns beers to @beers" do
-        subject
-        expect(assigns(:beers)).to eq(Beer.all)
+        it "assigns beers to @beers" do
+          subject
+          expect(assigns(:beers)).to eq(Beer.all)
+        end
+
+        it "assigns a new ballot to @ballot" do
+          subject
+          expect(assigns(:ballot)).to be_a_new(Ballot)
+        end
       end
 
-      it "assigns a new ballot to @ballot" do
-        subject
-        expect(assigns(:ballot)).to be_a_new(Ballot)
+      context "when there is no open poll" do
+        before(:each) { request.env["HTTP_REFERER"] = polls_path }
+
+        it "displays a warning message" do
+          subject
+          expect(flash[:warning]).to eq "There is no open poll to vote in currently!"
+        end
+
+        it "returns the user to their previous page" do
+          subject
+          expect(response).to redirect_to polls_path
+        end
       end
     end
 
-    context "when there is no open poll" do
-      before(:each) { request.env["HTTP_REFERER"] = polls_path }
+    context "when a user is not logged in" do
+      before(:each) { sign_out user }
 
-      it "displays a warning message" do
-        subject
-        expect(flash[:warning]).to eq "There is no open poll to vote in currently!"
-      end
-
-      it "returns the user to their previous page" do
-        subject
-        expect(response).to redirect_to polls_path
-      end
+      it { is_expected.to redirect_to new_user_session_path }
     end
   end
 

--- a/spec/controllers/beers_controller_spec.rb
+++ b/spec/controllers/beers_controller_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe BeersController, type: :controller do
 
     it "assigns all beers as @beers" do
       subject
-      expect(assigns(:beers)).to eq beers
+      expect(assigns(:beers)).to match_array beers
     end
   end
 


### PR DESCRIPTION
Currently if a user is not signed in and selects "Vote!" and error
occurs when the controller tries to access the current user. This will
simply redirect the user to the log in page with a message saying they
must sign in or sign up. After doing so, they will be redirected to the
voting page.

This should resolve #45  
