### PR TITLE
Don't crash on vote with no open poll

### DIFF
--- a/app/controllers/ballots_controller.rb
+++ b/app/controllers/ballots_controller.rb
@@ -5,7 +5,12 @@ class BallotsController < ApplicationController
   authorize_resource
 
   def new
-    @ballot = Ballot.new
+    if Poll.current
+      @ballot = Ballot.new
+    else
+      flash[:warning] = "There is no open poll to vote in currently!"
+      redirect_to :back
+    end
   end
 
   def create
@@ -47,7 +52,7 @@ class BallotsController < ApplicationController
 
   def load_all_beers
     @beers =
-      if brewery = Poll.current.brewery.presence
+      if brewery = Poll.current.try(:brewery)
         Beer.where(brewery: brewery)
       else
         Beer.all

--- a/spec/controllers/ballots_controller_spec.rb
+++ b/spec/controllers/ballots_controller_spec.rb
@@ -47,17 +47,34 @@ RSpec.describe BallotsController, type: :controller do
   end
 
   describe "GET #new" do
-    let!(:poll) { FactoryGirl.create :poll }
     subject { get :new }
 
-    it "assigns beers to @beers" do
-      subject
-      expect(assigns(:beers)).to eq(Beer.all)
+    context "when there is an open poll" do
+      let!(:poll) { FactoryGirl.create :poll }
+
+      it "assigns beers to @beers" do
+        subject
+        expect(assigns(:beers)).to eq(Beer.all)
+      end
+
+      it "assigns a new ballot to @ballot" do
+        subject
+        expect(assigns(:ballot)).to be_a_new(Ballot)
+      end
     end
 
-    it "assigns a new ballot to @ballot" do
-      subject
-      expect(assigns(:ballot)).to be_a_new(Ballot)
+    context "when there is no open poll" do
+      before(:each) { request.env["HTTP_REFERER"] = polls_path }
+
+      it "displays a warning message" do
+        subject
+        expect(flash[:warning]).to eq "There is no open poll to vote in currently!"
+      end
+
+      it "returns the user to their previous page" do
+        subject
+        expect(response).to redirect_to polls_path
+      end
     end
   end
 


### PR DESCRIPTION
Currently if a users clicks the Vote! button when there is no poll open,
the app will crash. This is caused by the `Poll.current.brewery` call when
loading the beers. This fixes that issue and also redirects the user
back to their previous page with a warning message.

This should resolve #49 
